### PR TITLE
Add some configuration documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,22 @@ Adds a command 'drupal' to Terminus which you can use just like 'drush' or 'wp'.
 
 This project is based on the [Terminus Composer](https://github.com/rvtraveller/terminus-composer) plugin.
 
+## Configuration
+
+In order for the Terminus Drupal Console plugin to work, you must configure your Drupal site.
+
+* Add Drupal Console to your Drupal site via `composer require`
+* Add a Drupal Console configuration file to console/config.yml
+
+The config.yml file should contain (at a minimum):
+```
+application:
+    options:
+        root: web
+```
 ## Examples
 * `terminus drupal "list" --site=my-site --env=dev`
 * `terminus drupal "theme:debug" --site=my-site --env=dev`
-
 
 ## Installation
 For help installing, see [Terminus's Wiki](https://github.com/pantheon-systems/terminus/wiki/Plugins)


### PR DESCRIPTION
At the moment, this plugin will not work unless the target site has been suitably prepared. This will not be necessary in the future.